### PR TITLE
Colours ahoy

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -827,7 +827,7 @@ public sealed partial class ChatUIController : UIController
     public void ProcessChatMessage(ChatMessage msg, bool speechBubble = true)
     {
         // color the name unless it's something like "the old man"
-        if ((msg.Channel == ChatChannel.Local || msg.Channel == ChatChannel.Whisper) && _chatNameColorsEnabled)
+        if ((msg.Channel == ChatChannel.Local || msg.Channel == ChatChannel.Whisper || msg.Channel == ChatChannel.Emotes || msg.Channel == ChatChannel.Subtle) && _chatNameColorsEnabled)
         {
             var grammar = _ent.GetComponentOrNull<GrammarComponent>(_ent.GetEntity(msg.SenderEntity));
             if (grammar != null && grammar.ProperNoun == true)

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -31,12 +31,12 @@ chat-manager-entity-whisper-unknown-wrap-message = [font size=11][italic][Bubble
 # THE() is not used here because the entity and its name can technically be disconnected if a nameOverride is passed...
 chat-manager-entity-me-wrap-message = [italic]{ PROPER($entity) ->
     *[false] The {$entityName} {$message}[/italic]
-     [true] {CAPITALIZE($entityName)} {$message}[/italic]
+     [true] [Name]{CAPITALIZE($entityName)}[/Name] {$message}[/italic]
     }
 
 chat-manager-entity-subtle-wrap-message = [italic]{ PROPER($entity) ->
     *[false] the {$entityName} subtly {$message}[/italic]
-     [true] {$entityName} subtly {$message}[/italic]
+     [true] [Name]{$entityName}[/Name] subtly {$message}[/italic]
     }
 
 chat-manager-entity-looc-wrap-message = LOOC: [bold]{$entityName}:[/bold] {$message}


### PR DESCRIPTION
## About the PR
"Add colors to characters names" now adds colors to Emotes and Subtles

## Why / Balance
We use the accessibility option to be able to easily parse groups of messages, prior to this emotes and subtles wouldn't have highlighting, which made reading them difficult

It uses the exact same system as regular name highlights, so there are no worries about revealing your identity by emoting.

## Technical details
Localization changes and a few operator additions

## How to test
Try to emote
Rejoice in colour
Try to Subtle
Rejoice in colour

## Media
![image](https://github.com/user-attachments/assets/3a1e7fd9-292e-4f50-9197-820f41e142de)

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
I don't think so

**Changelog**
:cl:
- tweak: The accessability option to highlight names for speech now works for non-verbal actions as well.
